### PR TITLE
Fix Travis builds and upgrade dependency scopes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,75 @@
+# Use container-based Travis, with the Trusty image.
+# See https://docs.travis-ci.com/user/reference/overview/ and https://docs.travis-ci.com/user/reference/trusty/
+sudo: false
+dist: trusty
+
 language: android
 jdk:
   - oraclejdk8
 env:
   global:
-    # Remember to keep this in sync with config.properties
+    # Remember to keep these four values in sync with config.properties
     - compileSdkVersion=26
     - minSdkVersion=23
     - targetSdkVersion=23
     - toolsVersion=27.0.3
-    - ANDROID_ABI=armeabi-v7a
+    # Emulator-specific
+    - emulatorApiVersion=23
+    - androidAbiVersion=armeabi-v7a
+    - androidTag=google_apis
+    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
+    # For the decryption of secrets needed to sign and publish our artifacts
     - secure: "LipL0wPv0uQrKitaeGxCpoQsx5sl/Pg/DtQv4S7Bi52DxfArgvD2hPB0TWgkgYGJPfENHLEyqg+H+/v2nON3IXY+cnsd+TW+P1T03/52D56ieSKGVtVtSYUOZUgoyxIIvRZWFh/UNg+AmZIjOCTJDLitBTUxD8kWux8NjhIqZow="
 android:
   components:
-    # The SDK version used to compile your project
-    - android-${compileSdkVersion}
-
-    # The BuildTools version used by your project
-    - tools
+    # Android tools
+    - tools # to get the new `repository-11.xml`
+    - platform-tools
+    - tools # to install up-to-date Android SDK tools
     - build-tools-${toolsVersion}
 
-    # if you need to run emulator(s) during your tests
-    - sys-img-${ANDROID_ABI}-android-${targetSdkVersion}
+    # SDK versions
+    - android-${compileSdkVersion}
+    - android-${emulatorApiVersion}
 
-before_install: ./ciLicense.sh
+    # I'm not sure why these are needed
+    - addon-google_apis-google-${compileSdkVersion}
+    - addon-google_apis-google-${emulatorApiVersion}
+    - extra-android-support
 
-# Emulator Management: Create, Start and Wait
+    # Latest artifacts in local repository
+    - extra-google-m2repository
+    - extra-android-m2repository
+
+    # Emulator system image
+    - sys-img-${androidAbiVersion}-${androidTag}-${emulatorApiVersion}
+
+before_install:
+  - ./ciLicense.sh
+
+install:
+  - ./gradlew build
+
 before_script:
-  - echo no | android create avd --force -n test -t android-${targetSdkVersion} --abi ${ANDROID_ABI}
-  - emulator -avd test -no-audio -no-window &
+  # Log what we've got installed (useful in case issues occur)
+  - sdkmanager --list
+  - android list targets
+
+  # Create and start emulator
+  - echo no | android create avd --force -n test -t android-${emulatorApiVersion} --abi ${androidAbiVersion} --tag ${androidTag}
+  - export QEMU_AUDIO_DRV=none && emulator -avd test -no-window &
+
+  # Wait for emulator to be ready, then start log capture
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+  - adb wait-for-device get-serialno
+  - adb logcat > logcat.log &
 
-after_success: ./ciPublish.sh
+script:
+  - travis_wait 30 ./gradlew connectedCheck
+
+after_success:
+  - cat logcat.log
+  - ./ciPublish.sh
+
+after_failure: cat logcat.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,23 @@ env:
     - secure: "LipL0wPv0uQrKitaeGxCpoQsx5sl/Pg/DtQv4S7Bi52DxfArgvD2hPB0TWgkgYGJPfENHLEyqg+H+/v2nON3IXY+cnsd+TW+P1T03/52D56ieSKGVtVtSYUOZUgoyxIIvRZWFh/UNg+AmZIjOCTJDLitBTUxD8kWux8NjhIqZow="
 android:
   components:
-    # Android tools
-    - tools # to get the new `repository-11.xml`
+    # Android tools - it's deliberate that `tools` is in there twice, see https://docs.travis-ci.com/user/languages/android/#Installing-a-newer-SDK-Platform-Tools-revision
+    - tools  # to download the latest listing of what's available to download
     - platform-tools
-    - tools # to install up-to-date Android SDK tools
+    - tools  # to install up-to-date Android SDK tools
     - build-tools-${toolsVersion}
 
     # SDK versions
     - android-${compileSdkVersion}
     - android-${emulatorApiVersion}
 
-    # I'm not sure why these are needed
+    # I'm not sure why these are needed, but the emulator fails without them.  It's probably
+    # because we're using the Google APIs tag.
     - addon-google_apis-google-${compileSdkVersion}
     - addon-google_apis-google-${emulatorApiVersion}
     - extra-android-support
 
-    # Latest artifacts in local repository
+    # Ensure the latest artifacts are available in local Maven repository
     - extra-google-m2repository
     - extra-android-m2repository
 
@@ -66,10 +67,12 @@ before_script:
   - adb logcat > logcat.log &
 
 script:
+  # By default, Travis errors if no console output is received for >10 mins.  Since running a
+  # test with an emulator can be very slow, we give ourselves a broader window.
   - travis_wait 30 ./gradlew connectedCheck
 
 after_success:
-  - cat logcat.log
   - ./ciPublish.sh
 
-after_failure: cat logcat.log
+after_failure:
+  - cat logcat.log

--- a/config.properties
+++ b/config.properties
@@ -1,6 +1,8 @@
-# Android 7.1.1, 7.1  25  N_MR1
-# Android 7.0         24  N
-# Android 6.0         23  M
+# Android 8.1         27  OREO_MR1
+# Android 8.0         26  OREO
+# Android 7.1.1, 7.1  25  NOUGAT_MR1
+# Android 7.0         24  NOUGAT
+# Android 6.0         23  MARSHMALLOW
 # Android 5.1         22  LOLLIPOP_MR1
 # Android 5.0         21  LOLLIPOP
 # Android 4.4W        20  KITKAT_WATCH
@@ -14,4 +16,4 @@ targetSdkVersion=23
 
 toolsVersion=27.0.3
 
-# Remember to keep this in sync with .travis.yml
+# Remember to keep these values in sync with .travis.yml

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -6,7 +6,6 @@ dependencies {
 
   androidTestImplementation 'com.android.support.test.espresso:espresso-core:2.2.2'
   androidTestImplementation 'com.android.support.test:runner:0.5'
-  androidTestImplementation 'com.android.support:support-annotations:25.3.1'
 }
 
 android {

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -1,12 +1,12 @@
 evaluationDependsOn(':libraries:cyclestreets-fragments')
 
 dependencies {
-  compile project(':libraries:cyclestreets-fragments')
-  compile 'ch.acra:acra:4.9.0'
+  api project(':libraries:cyclestreets-fragments')
+  implementation 'ch.acra:acra:4.9.2'
 
-  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-  androidTestCompile 'com.android.support.test:runner:0.5'
-  androidTestCompile 'com.android.support:support-annotations:25.3.1'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-core:2.2.2'
+  androidTestImplementation 'com.android.support.test:runner:0.5'
+  androidTestImplementation 'com.android.support:support-annotations:25.3.1'
 }
 
 android {

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -4,33 +4,33 @@ configurations {
 }
 
 dependencies {
-  compile 'org.osmdroid:osmdroid-android:5.6.5'
-  compile 'org.slf4j:slf4j-android:1.7.21'
+  api 'org.osmdroid:osmdroid-android:5.6.5'
+  api 'org.slf4j:slf4j-android:1.7.21'
 
   // Retrofit for HTTP Client activities
-  compile 'com.squareup.retrofit2:retrofit:2.1.0'
-  compile 'com.squareup.retrofit2:converter-scalars:2.1.0'
-  compile('com.squareup.retrofit2:converter-simplexml:2.1.0') {
+  api 'com.squareup.retrofit2:retrofit:2.1.0'
+  implementation 'com.squareup.retrofit2:converter-scalars:2.1.0'
+  implementation('com.squareup.retrofit2:converter-simplexml:2.1.0') {
     // Exclusions required as per https://github.com/square/retrofit/issues/1796
     exclude group: 'xpp3', module: 'xpp3'
     exclude group: 'stax', module: 'stax-api'
     exclude group: 'stax', module: 'stax'
   }
-  compile 'com.squareup.retrofit2:converter-jackson:2.1.0'
-  compile 'de.grundid.opendatalab:geojson-jackson:1.6'
+  implementation 'com.squareup.retrofit2:converter-jackson:2.1.0'
+  implementation 'de.grundid.opendatalab:geojson-jackson:1.6'
 
   // Jackson is already included transitively from multiple sources; we specify explicit versions
   // to ensure consistency across these artifacts.
-  compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.7'
-  compile 'com.fasterxml.jackson.core:jackson-core:2.7.7'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.7.7'
+  implementation 'com.fasterxml.jackson.core:jackson-annotations:2.7.7'
+  implementation 'com.fasterxml.jackson.core:jackson-core:2.7.7'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.7.7'
 
-  testCompile 'com.github.tomakehurst:wiremock-standalone:2.1.12'
-  testCompile 'junit:junit:4.12'
-  testCompile 'org.hamcrest:hamcrest-all:1.3'
-  testCompile 'org.mockito:mockito-core:1.10.19'
-  testCompile 'org.robolectric:robolectric:3.3.2'
-  testCompile 'commons-io:commons-io:2.5'
+  testImplementation 'com.github.tomakehurst:wiremock-standalone:2.1.12'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.hamcrest:hamcrest-all:1.3'
+  testImplementation 'org.mockito:mockito-core:1.10.19'
+  testImplementation 'org.robolectric:robolectric:3.3.2'
+  testImplementation 'commons-io:commons-io:2.5'
 }
 
 def buildNumber = {

--- a/libraries/cyclestreets-fragments/build.gradle
+++ b/libraries/cyclestreets-fragments/build.gradle
@@ -1,6 +1,6 @@
 evaluationDependsOn(':libraries:cyclestreets-view')
 
 dependencies {
-  compile project(':libraries:cyclestreets-view')
-  compile 'com.jjoe64:graphview:3.1.4'
+  api project(':libraries:cyclestreets-view')
+  implementation 'com.jjoe64:graphview:3.1.4'
 }

--- a/libraries/cyclestreets-track/build.gradle
+++ b/libraries/cyclestreets-track/build.gradle
@@ -1,5 +1,5 @@
 evaluationDependsOn(':libraries:cyclestreets-view')
 
 dependencies {
-  compile project(':libraries:cyclestreets-view')
+  implementation project(':libraries:cyclestreets-view')
 }

--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -1,13 +1,13 @@
 evaluationDependsOn(':libraries:cyclestreets-core')
 
 dependencies {
-  compile project(':libraries:cyclestreets-core')
-  compile files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')
-  compile 'com.getpebble:pebblekit:3.1.0@aar'
+  api project(':libraries:cyclestreets-core')
+  api files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')
+  implementation 'com.getpebble:pebblekit:3.1.0@aar'
 
   // In the main app project, we're already pulling in 23.x via the `acra` dependency.
-  compile 'com.android.support:appcompat-v7:27.0.2'
-  compile 'com.android.support:support-v4:27.0.2'
-  compile 'com.android.support:support-annotations:27.0.2'
-  compile 'com.android.support:design:27.0.2'
+  api 'com.android.support:appcompat-v7:27.0.2'
+  api 'com.android.support:support-v4:27.0.2'
+  api 'com.android.support:support-annotations:27.0.2'
+  api 'com.android.support:design:27.0.2'
 }

--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -5,7 +5,6 @@ dependencies {
   api files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')
   implementation 'com.getpebble:pebblekit:3.1.0@aar'
 
-  // In the main app project, we're already pulling in 23.x via the `acra` dependency.
   api 'com.android.support:appcompat-v7:27.0.2'
   api 'com.android.support:support-v4:27.0.2'
   api 'com.android.support:support-annotations:27.0.2'

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.java
@@ -5,12 +5,12 @@ import android.content.pm.PackageManager;
 
 public class Permissions {
   public static boolean verify(final Activity activity, final String permission) {
-    if (!hasPermssion(activity, permission))
+    if (!hasPermission(activity, permission))
       activity.requestPermissions(new String[]{ permission }, 1);
-    return hasPermssion(activity, permission);
+    return hasPermission(activity, permission);
   } // verify
 
-  private static boolean hasPermssion(final Activity activity, final String permission) {
+  private static boolean hasPermission(final Activity activity, final String permission) {
     return activity.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED;
   } // hasPermission
 } // class Permissions


### PR DESCRIPTION
This PR adds to the outstanding ["Housekeeping, and start of material design work" PR](https://github.com/cyclestreets/android/pull/202).

In this, we:
1.  fix the Travis builds
2.  update dependency scopes as per the obsoletion notice given in logs and at https://github.com/jezhiggins/cyclestreets-android/commit/6cd901a120b78f2ab20ca55a151b21f134d53ad1.